### PR TITLE
fix(deps): patch phpunit security vulnerability (CIP-2731)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "laravel/pint": "1.20.0",
         "phpstan/phpstan": "2.1.17",
-        "phpunit/phpunit": "10.5.46"
+        "phpunit/phpunit": "10.5.62"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

- **phpunit/phpunit**: 10.5.46 → 10.5.62 (CVE-2026-24765)

Safe patch bump within 10.5.x series. Addresses Vanta HIGH vulnerability with SLA Feb 27.

No composer.lock in git (library pattern) — CI will validate the version resolution.

## Linear Issues

- CIP-2731

## Test plan

- [x] composer.json updated to 10.5.62
- [ ] CI passes (`composer test:unit`)